### PR TITLE
Make timeSkew milliseconds for enhanced accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _getUser: function() {
 
 ## Properties
 
-### _timeSkew
+### _clientTimeSkew
 This property tracks the difference in time between the users local machine and that of the server, in milliseconds. This can be useful for clients to more accurately determine things like token expiry.
 
 ## Functions

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _getUser: function() {
 ## Properties
 
 ### _clientTimeSkew
-This property tracks the difference in time between the users local machine and that of the server, in milliseconds. This can be useful for clients to more accurately determine things like token expiry.
+This property tracks the difference in time between the users local machine and that of the server, in milliseconds. The value is in relation to the time from the server, so positive values indicate that the client is that many milliseconds into the future (relative to the server) whereas negative values indicate the number of milliseconds the client is in the past. This can be useful for clients to more accurately determine things like token expiry.
 
 ## Functions
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ _getUser: function() {
 },
 ```
 
+## Properties
+
+### _timeSkew
+This property tracks the difference in time between the users local machine and that of the server, in milliseconds. This can be useful for clients to more accurately determine things like token expiry.
+
+## Functions
+
 ### _fetchEntity
 This function does not provide authorization headers, relying on d2l middleware to apply any if applicable.
 This function is best used for requests that do not require auth or that are ok to be made in the context of the logged in user.

--- a/d2l-fetch-siren-entity-behavior.html
+++ b/d2l-fetch-siren-entity-behavior.html
@@ -46,7 +46,7 @@
 				.then(function(response) {
 					if (response.ok) {
 						var serverTimeUtc = new Date(response.headers.get('Date'));
-						self._timeSkew = Math.round(serverTimeUtc / 1000) - Math.round(self._getCurrentTime() / 1000);
+						self._timeSkew = serverTimeUtc - self._getCurrentTime();
 						return response.json();
 					}
 					return Promise.reject(response.status);

--- a/d2l-fetch-siren-entity-behavior.html
+++ b/d2l-fetch-siren-entity-behavior.html
@@ -9,7 +9,7 @@
 	var fetchSirenEntityBehaviorImpl = {
 
 		properties: {
-			_timeSkew: Number
+			_clientTimeSkew: Number
 		},
 
 		_fetchEntity: function(url) {
@@ -46,7 +46,7 @@
 				.then(function(response) {
 					if (response.ok) {
 						var serverTimeUtc = new Date(response.headers.get('Date'));
-						self._timeSkew = serverTimeUtc - self._getCurrentTime();
+						self._clientTimeSkew = serverTimeUtc - self._getCurrentTime();
 						return response.json();
 					}
 					return Promise.reject(response.status);

--- a/test/d2l-fetch-siren-entity-behavior.js
+++ b/test/d2l-fetch-siren-entity-behavior.js
@@ -145,30 +145,30 @@ describe('d2l-fetch-siren-entity-behavior', function() {
 				});
 		});
 
-		it('should set _timeSkew to the difference between now and server time when the fetch response is ok', function() {
+		it('should set _clientTimeSkew to the difference between now and server time when the fetch response is ok', function() {
 			window.d2lfetch.fetch.returns(Promise.resolve(goodResponse));
 			component._getCurrentTime = sandbox.stub().returns(new Date('2017-10-24T16:00:00.000Z'));
 			return component._makeRequest(new Request('some-url'))
 				.then(function() {
-					expect(component._timeSkew).to.equal(0);
+					expect(component._clientTimeSkew).to.equal(0);
 				});
 		});
 
-		it('should set _timeSkew to 60000 when the client is ahead of the server by one minute', function() {
+		it('should set _clientTimeSkew to 60000 when the client is ahead of the server by one minute', function() {
 			window.d2lfetch.fetch.returns(Promise.resolve(goodResponse));
 			component._getCurrentTime = sandbox.stub().returns(new Date('2017-10-24T15:59:00.000Z'));
 			return component._makeRequest(new Request('some-url'))
 				.then(function() {
-					expect(component._timeSkew).to.equal(60000);
+					expect(component._clientTimeSkew).to.equal(60000);
 				});
 		});
 
-		it('should set _timeSkew to -60000 when the server is ahead of the client by one minute', function() {
+		it('should set _clientTimeSkew to -60000 when the server is ahead of the client by one minute', function() {
 			window.d2lfetch.fetch.returns(Promise.resolve(goodResponse));
 			component._getCurrentTime = sandbox.stub().returns(new Date('2017-10-24T16:01:00.000Z'));
 			return component._makeRequest(new Request('some-url'))
 				.then(function() {
-					expect(component._timeSkew).to.equal(-60000);
+					expect(component._clientTimeSkew).to.equal(-60000);
 				});
 		});
 

--- a/test/d2l-fetch-siren-entity-behavior.js
+++ b/test/d2l-fetch-siren-entity-behavior.js
@@ -154,21 +154,21 @@ describe('d2l-fetch-siren-entity-behavior', function() {
 				});
 		});
 
-		it('should set _timeSkew to 60 when the client is ahead of the server by one minute', function() {
+		it('should set _timeSkew to 60000 when the client is ahead of the server by one minute', function() {
 			window.d2lfetch.fetch.returns(Promise.resolve(goodResponse));
 			component._getCurrentTime = sandbox.stub().returns(new Date('2017-10-24T15:59:00.000Z'));
 			return component._makeRequest(new Request('some-url'))
 				.then(function() {
-					expect(component._timeSkew).to.equal(60);
+					expect(component._timeSkew).to.equal(60000);
 				});
 		});
 
-		it('should set _timeSkew to -60 when the server is ahead of the client by one minute', function() {
+		it('should set _timeSkew to -60000 when the server is ahead of the client by one minute', function() {
 			window.d2lfetch.fetch.returns(Promise.resolve(goodResponse));
 			component._getCurrentTime = sandbox.stub().returns(new Date('2017-10-24T16:01:00.000Z'));
 			return component._makeRequest(new Request('some-url'))
 				.then(function() {
-					expect(component._timeSkew).to.equal(-60);
+					expect(component._timeSkew).to.equal(-60000);
 				});
 		});
 


### PR DESCRIPTION
Being in seconds resulted in a math bug in recent grades. I think milliseconds will lead to less complicated date mathing overall.