### PR TITLE
Use non-global siren-parser-import

### DIFF
--- a/d2l-fetch-siren-entity-behavior.html
+++ b/d2l-fetch-siren-entity-behavior.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-fetch/d2l-fetch.html">
-<link rel="import" href="../siren-parser-import/siren-parser-global.html">
+<link rel="import" href="../siren-parser-import/siren-parser.html">
 
 <script>
 	'use strict';


### PR DESCRIPTION
The global one is only really required for UMD FRAs, and this wasn't previously using it, so it's safe to use the non-global one.