### PR TITLE
Add whitelist support to prevent sending tokens to malicious actors

### DIFF
--- a/d2l-fetch-siren-entity-behavior.html
+++ b/d2l-fetch-siren-entity-behavior.html
@@ -15,7 +15,15 @@
 	D2L.PolymerBehaviors.FetchSirenEntityBehavior = {
 
 		properties: {
-			_clientTimeSkew: Number
+			_clientTimeSkew: Number,
+			__whitelistedDomains: {
+				type: Array,
+				value: [
+					'api.proddev.d2l',
+					'api.dev.brightspace.com',
+					'api.brightspace.com'
+				]
+			}
 		},
 
 		_fetchEntity: function(url) {
@@ -26,6 +34,11 @@
 		},
 
 		_fetchEntityWithToken: function(url, getToken, userUrl) {
+
+			if (!url || !this._isWhitelisted(url)) {
+				return Promise.reject(new Error('Invalid request url; must be a valid whitelisted domain.'));
+			}
+
 			var tokenUrl = userUrl || url;
 			if (url && typeof getToken === 'function' && tokenUrl) {
 				return getToken(tokenUrl)
@@ -64,6 +77,42 @@
 		// this function is purely for mocking out while testing
 		_getCurrentTime: function() {
 			return new Date();
+		},
+
+		_addDomains: function(domains) {
+			if (domains && domains instanceof Array) {
+				this.__whitelistedDomains = this.__mergeAndDedupe(this.__whitelistedDomains, domains);
+			}
+		},
+
+		__mergeAndDedupe: function(array1, array2) {
+			var result = [];
+			var observed = {};
+			var all = array1.concat(array2);
+
+			all.forEach(function(item) {
+				if (!observed[item]) {
+					result.push(item);
+					observed[item] = true;
+				}
+			});
+
+			return result;
+		},
+
+		_isWhitelisted: function(url) {
+			// expression taken from URI spec parsing section: https://tools.ietf.org/html/rfc3986#appendix-B
+			var uriExpression = /^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
+			var host = url.match(uriExpression)[4];
+			if (!host) {
+				return false;
+			}
+			return 0 <= this.__whitelistedDomains.findIndex(function(domain) {
+				if (domain === host) {
+					return true;
+				}
+				return host.endsWith('.' + domain);
+			});
 		}
 
 	};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run test:lint:js && npm run test:lint:wc",
     "test:lint:js": "eslint *.html",
     "test:lint:wc": "polymer lint -i *.html",
-    "test:unit:local": "polymer test --skip-plugin sauce"
+    "test:unit:local": "cross-env LAUNCHPAD_BROWSERS=chrome polymer test --skip-plugin sauce"
   },
   "homepage": "https://github.com/Brightspace/d2l-fetch-siren-entity-behavior",
   "repository": {


### PR DESCRIPTION
[DE29683 - User can enter arbitrary url into userActivityUsageHref queryparam and we hit that with a token](https://rally1.rallydev.com/#/157196228032d/detail/defect/210464073620)

Polymer behavior implementation of https://github.com/Brightspace/d2l-fetch-whitelist/pull/1

TODO:
- [ ] Switch from `domain` whitelist to `origin`, per [Owen's comment here](https://github.com/Brightspace/d2l-fetch-whitelist/pull/1#pullrequestreview-109770698).