### PR TITLE
Add iron-meta for whitelist monostate

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,10 +21,11 @@
     "wct.conf.json"
   ],
   "dependencies": {
-     "d2l-fetch": "Brightspace/d2l-fetch#^1.7.0",
-     "polymer": "1 - 2",
-     "siren-parser-import": "Brightspace/siren-parser-import#^7.0.0"
-   },
+    "d2l-fetch": "Brightspace/d2l-fetch#^1.7.0",
+    "polymer": "1 - 2",
+    "siren-parser-import": "Brightspace/siren-parser-import#^7.0.0",
+    "iron-meta": "PolymerElements/iron-meta#^2.1.1"
+  },
   "devDependencies": {
     "web-component-tester": "^6.0.0"
   },

--- a/d2l-fetch-siren-entity-behavior.html
+++ b/d2l-fetch-siren-entity-behavior.html
@@ -21,15 +21,15 @@
 		registered: function() {
 			window.D2L.PolymerBehaviors.FetchSirenEntityBehaviorMeta = window.D2L.PolymerBehaviors.FetchSirenEntityBehaviorMeta
 				|| new Polymer.IronMeta(
-				{
-					key: 'whitelistedDomains',
-					value: [
-						'api.proddev.d2l',
-						'api.dev.brightspace.com',
-						'api.brightspace.com'
-					]
-				}
-			);
+					{
+						key: 'whitelistedDomains',
+						value: [
+							'api.proddev.d2l',
+							'api.dev.brightspace.com',
+							'api.brightspace.com'
+						]
+					}
+				);
 		},
 
 		_fetchEntity: function(url) {

--- a/d2l-fetch-siren-entity-behavior.html
+++ b/d2l-fetch-siren-entity-behavior.html
@@ -15,15 +15,21 @@
 	D2L.PolymerBehaviors.FetchSirenEntityBehavior = {
 
 		properties: {
-			_clientTimeSkew: Number,
-			__whitelistedDomains: {
-				type: Array,
-				value: [
-					'api.proddev.d2l',
-					'api.dev.brightspace.com',
-					'api.brightspace.com'
-				]
-			}
+			_clientTimeSkew: Number
+		},
+
+		registered: function() {
+			window.D2L.PolymerBehaviors.FetchSirenEntityBehaviorMeta = window.D2L.PolymerBehaviors.FetchSirenEntityBehaviorMeta
+				|| new Polymer.IronMeta(
+				{
+					key: 'whitelistedDomains',
+					value: [
+						'api.proddev.d2l',
+						'api.dev.brightspace.com',
+						'api.brightspace.com'
+					]
+				}
+			);
 		},
 
 		_fetchEntity: function(url) {
@@ -81,7 +87,10 @@
 
 		_addDomains: function(domains) {
 			if (domains && domains instanceof Array) {
-				this.__whitelistedDomains = this.__mergeAndDedupe(this.__whitelistedDomains, domains);
+				new Polymer.IronMeta({ key: 'whitelistedDomains'}).value = this.__mergeAndDedupe(
+					this._getWhitelist(),
+					domains
+				);
 			}
 		},
 
@@ -98,6 +107,10 @@
 			});
 
 			return result;
+		},
+
+		_getWhitelist: function() {
+			return window.D2L.PolymerBehaviors.FetchSirenEntityBehaviorMeta.byKey('whitelistedDomains');
 		},
 
 		_isWhitelisted: function(url) {
@@ -121,12 +134,13 @@
 			if (!host) {
 				return false;
 			}
-			return 0 <= this.__whitelistedDomains.findIndex(function(domain) {
-				if (domain === host) {
-					return true;
-				}
-				return host.endsWith('.' + domain);
-			});
+			return 0 <= this._getWhitelist()
+				.findIndex(function(domain) {
+					if (domain === host) {
+						return true;
+					}
+					return host.endsWith('.' + domain);
+				});
 		}
 
 	};


### PR DESCRIPTION
The original implementation resulted in the whitelist being overwritten when multiple components implemented the behavior and some were registered after additional whitelist entries were added. This change prevents that by implementing a monostate whitelist via the `iron-meta` component.