### PR TITLE
adding eslintrc for tests

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "brightspace/wct-polymer-3-config"
+}


### PR DESCRIPTION
This is so that we don't need to ignore the `WCT` warning after the P3 upgrade.